### PR TITLE
Change _id column type from Int to bigint across all tables

### DIFF
--- a/App01/db-init.sql
+++ b/App01/db-init.sql
@@ -12,7 +12,7 @@ CREATE TABLE IF NOT EXISTS `accelerometer` (
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8;
 
 CREATE TABLE IF NOT EXISTS `applications_crashes` (
-  `_id` int(11) NOT NULL AUTO_INCREMENT,
+  `_id` bigint unsigned NOT NULL AUTO_INCREMENT,
   `timestamp` double DEFAULT '0',
   `device_id` varchar(150) DEFAULT '',
   `package_name` text,
@@ -27,7 +27,7 @@ CREATE TABLE IF NOT EXISTS `applications_crashes` (
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8;
 
 CREATE TABLE IF NOT EXISTS `applications_foreground` (
-  `_id` int(11) NOT NULL AUTO_INCREMENT,
+  `_id` bigint unsigned NOT NULL AUTO_INCREMENT,
   `timestamp` double DEFAULT '0',
   `device_id` varchar(150) DEFAULT '',
   `package_name` text,
@@ -38,7 +38,7 @@ CREATE TABLE IF NOT EXISTS `applications_foreground` (
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8;
 
 CREATE TABLE IF NOT EXISTS `applications_history` (
-  `_id` int(11) NOT NULL AUTO_INCREMENT,
+  `_id` bigint unsigned NOT NULL AUTO_INCREMENT,
   `timestamp` double DEFAULT '0',
   `device_id` varchar(150) DEFAULT '',
   `package_name` text,
@@ -52,7 +52,7 @@ CREATE TABLE IF NOT EXISTS `applications_history` (
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8;
 
 CREATE TABLE IF NOT EXISTS `applications_notifications` (
-  `_id` int(11) NOT NULL AUTO_INCREMENT,
+  `_id` bigint unsigned NOT NULL AUTO_INCREMENT,
   `timestamp` double DEFAULT '0',
   `device_id` varchar(150) DEFAULT '',
   `package_name` text,
@@ -67,7 +67,7 @@ CREATE TABLE IF NOT EXISTS `applications_notifications` (
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8;
 
 CREATE TABLE IF NOT EXISTS `aware_device` (
-  `_id` int(11) NOT NULL AUTO_INCREMENT,
+  `_id` bigint unsigned NOT NULL AUTO_INCREMENT,
   `timestamp` double DEFAULT '0',
   `device_id` varchar(150) DEFAULT '',
   `board` text,
@@ -88,7 +88,7 @@ CREATE TABLE IF NOT EXISTS `aware_device` (
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8;
 
 CREATE TABLE IF NOT EXISTS `aware_log` (
-  `_id` int(11) NOT NULL AUTO_INCREMENT,
+  `_id` bigint unsigned NOT NULL AUTO_INCREMENT,
   `timestamp` double DEFAULT '0',
   `device_id` varchar(150) DEFAULT '',
   `log_message` text,
@@ -97,7 +97,7 @@ CREATE TABLE IF NOT EXISTS `aware_log` (
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8;
 
 CREATE TABLE IF NOT EXISTS `aware_studies` (
-  `_id` int(11) NOT NULL AUTO_INCREMENT,
+  `_id` bigint unsigned NOT NULL AUTO_INCREMENT,
   `timestamp` double DEFAULT '0',
   `device_id` varchar(150) DEFAULT '',
   `study_url` text,
@@ -115,7 +115,7 @@ CREATE TABLE IF NOT EXISTS `aware_studies` (
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8;
 
 CREATE TABLE IF NOT EXISTS `barometer` (
-  `_id` int(11) NOT NULL AUTO_INCREMENT,
+  `_id` bigint unsigned NOT NULL AUTO_INCREMENT,
   `timestamp` double DEFAULT '0',
   `device_id` varchar(150) DEFAULT '',
   `double_values_0` double DEFAULT '0',
@@ -126,7 +126,7 @@ CREATE TABLE IF NOT EXISTS `barometer` (
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8;
 
 CREATE TABLE IF NOT EXISTS `battery` (
-  `_id` int(11) NOT NULL AUTO_INCREMENT,
+  `_id` bigint unsigned NOT NULL AUTO_INCREMENT,
   `timestamp` double DEFAULT '0',
   `device_id` varchar(150) DEFAULT '',
   `battery_status` int(11) DEFAULT '0',
@@ -142,7 +142,7 @@ CREATE TABLE IF NOT EXISTS `battery` (
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8;
 
 CREATE TABLE IF NOT EXISTS `battery_charges` (
-  `_id` int(11) NOT NULL AUTO_INCREMENT,
+  `_id` bigint unsigned NOT NULL AUTO_INCREMENT,
   `timestamp` double DEFAULT '0',
   `device_id` varchar(150) DEFAULT '',
   `battery_start` int(11) DEFAULT '0',
@@ -153,7 +153,7 @@ CREATE TABLE IF NOT EXISTS `battery_charges` (
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8;
 
 CREATE TABLE IF NOT EXISTS `battery_discharges` (
-  `_id` int(11) NOT NULL AUTO_INCREMENT,
+  `_id` bigint unsigned NOT NULL AUTO_INCREMENT,
   `timestamp` double DEFAULT '0',
   `device_id` varchar(150) DEFAULT '',
   `battery_start` int(11) DEFAULT '0',
@@ -176,7 +176,7 @@ CREATE TABLE IF NOT EXISTS `bluetooth` (
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8;
 
 CREATE TABLE IF NOT EXISTS `calls` (
-  `_id` int(11) NOT NULL AUTO_INCREMENT,
+  `_id` bigint unsigned NOT NULL AUTO_INCREMENT,
   `timestamp` double DEFAULT '0',
   `device_id` varchar(150) DEFAULT '',
   `call_type` int(11) DEFAULT '0',
@@ -187,7 +187,7 @@ CREATE TABLE IF NOT EXISTS `calls` (
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8;
 
 CREATE TABLE IF NOT EXISTS `cdma` (
-  `_id` int(11) NOT NULL AUTO_INCREMENT,
+  `_id` bigint unsigned NOT NULL AUTO_INCREMENT,
   `timestamp` double DEFAULT '0',
   `device_id` varchar(150) DEFAULT '',
   `base_station_id` int(11) DEFAULT '0',
@@ -205,7 +205,7 @@ CREATE TABLE IF NOT EXISTS `cdma` (
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8;
 
 CREATE TABLE IF NOT EXISTS `esms` (
-  `_id` int(11) NOT NULL AUTO_INCREMENT,
+  `_id` bigint unsigned NOT NULL AUTO_INCREMENT,
   `timestamp` double DEFAULT '0',
   `device_id` varchar(150) DEFAULT '',
   `esm_json` text,
@@ -220,7 +220,7 @@ CREATE TABLE IF NOT EXISTS `esms` (
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8;
 
 CREATE TABLE IF NOT EXISTS `fitbit_data` (
-  `_id` int(11) NOT NULL AUTO_INCREMENT,
+  `_id` bigint unsigned NOT NULL AUTO_INCREMENT,
   `timestamp` double DEFAULT '0',
   `device_id` varchar(150) DEFAULT '',
   `fitbit_id` text,
@@ -231,7 +231,7 @@ CREATE TABLE IF NOT EXISTS `fitbit_data` (
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8;
 
 CREATE TABLE IF NOT EXISTS `fitbit_devices` (
-  `_id` int(11) NOT NULL AUTO_INCREMENT,
+  `_id` bigint unsigned NOT NULL AUTO_INCREMENT,
   `timestamp` double DEFAULT '0',
   `device_id` varchar(150) DEFAULT '',
   `fitbit_id` text,
@@ -244,7 +244,7 @@ CREATE TABLE IF NOT EXISTS `fitbit_devices` (
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8;
 
 CREATE TABLE IF NOT EXISTS `fused_geofences` (
-  `_id` int(11) NOT NULL AUTO_INCREMENT,
+  `_id` bigint unsigned NOT NULL AUTO_INCREMENT,
   `timestamp` double DEFAULT '0',
   `device_id` varchar(150) DEFAULT '',
   `geofence_label` text,
@@ -256,7 +256,7 @@ CREATE TABLE IF NOT EXISTS `fused_geofences` (
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8;
 
 CREATE TABLE IF NOT EXISTS `fused_geofences_data` (
-  `_id` int(11) NOT NULL AUTO_INCREMENT,
+  `_id` bigint unsigned NOT NULL AUTO_INCREMENT,
   `timestamp` double DEFAULT '0',
   `device_id` varchar(150) DEFAULT '',
   `geofence_label` text,
@@ -282,7 +282,7 @@ CREATE TABLE IF NOT EXISTS `gravity` (
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8;
 
 CREATE TABLE IF NOT EXISTS `gsm` (
-  `_id` int(11) NOT NULL AUTO_INCREMENT,
+  `_id` bigint unsigned NOT NULL AUTO_INCREMENT,
   `timestamp` double DEFAULT '0',
   `device_id` varchar(150) DEFAULT '',
   `cid` int(11) DEFAULT '-1',
@@ -295,7 +295,7 @@ CREATE TABLE IF NOT EXISTS `gsm` (
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8;
 
 CREATE TABLE IF NOT EXISTS `gsm_neighbor` (
-  `_id` int(11) NOT NULL AUTO_INCREMENT,
+  `_id` bigint unsigned NOT NULL AUTO_INCREMENT,
   `timestamp` double DEFAULT '0',
   `device_id` varchar(150) DEFAULT '',
   `cid` int(11) DEFAULT '-1',
@@ -320,7 +320,7 @@ CREATE TABLE IF NOT EXISTS `gyroscope` (
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8;
 
 CREATE TABLE IF NOT EXISTS `installations` (
-  `_id` int(11) NOT NULL AUTO_INCREMENT,
+  `_id` bigint unsigned NOT NULL AUTO_INCREMENT,
   `timestamp` double DEFAULT '0',
   `device_id` varchar(150) DEFAULT '',
   `package_name` text,
@@ -333,7 +333,7 @@ CREATE TABLE IF NOT EXISTS `installations` (
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8;
 
 CREATE TABLE IF NOT EXISTS `keyboard` (
-  `_id` int(11) NOT NULL AUTO_INCREMENT,
+  `_id` bigint unsigned NOT NULL AUTO_INCREMENT,
   `timestamp` double DEFAULT '0',
   `device_id` varchar(150) DEFAULT '',
   `package_name` text,
@@ -398,7 +398,7 @@ CREATE TABLE IF NOT EXISTS `magnetometer` (
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8;
 
 CREATE TABLE IF NOT EXISTS `messages` (
-  `_id` int(11) NOT NULL AUTO_INCREMENT,
+  `_id` bigint unsigned NOT NULL AUTO_INCREMENT,
   `timestamp` double DEFAULT '0',
   `device_id` varchar(150) DEFAULT '',
   `message_type` int(11) DEFAULT '0',
@@ -417,7 +417,7 @@ CREATE TABLE IF NOT EXISTS `mqtt_history` (
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8;
 
 CREATE TABLE IF NOT EXISTS `network` (
-  `_id` int(11) NOT NULL AUTO_INCREMENT,
+  `_id` bigint unsigned NOT NULL AUTO_INCREMENT,
   `timestamp` double DEFAULT '0',
   `device_id` varchar(150) DEFAULT '',
   `network_type` int(11) DEFAULT '0',
@@ -455,7 +455,7 @@ CREATE TABLE IF NOT EXISTS `plugin_ambient_noise` (
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8;
 
 CREATE TABLE IF NOT EXISTS `plugin_contacts` (
-  `_id` int(11) NOT NULL AUTO_INCREMENT,
+  `_id` bigint unsigned NOT NULL AUTO_INCREMENT,
   `timestamp` double DEFAULT '0',
   `device_id` varchar(150) DEFAULT '',
   `name` text,
@@ -468,7 +468,7 @@ CREATE TABLE IF NOT EXISTS `plugin_contacts` (
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8;
 
 CREATE TABLE IF NOT EXISTS `plugin_device_usage` (
-  `_id` int(11) NOT NULL AUTO_INCREMENT,
+  `_id` bigint unsigned NOT NULL AUTO_INCREMENT,
   `timestamp` double DEFAULT '0',
   `device_id` varchar(150) DEFAULT '',
   `double_elapsed_device_on` double DEFAULT '0',
@@ -478,7 +478,7 @@ CREATE TABLE IF NOT EXISTS `plugin_device_usage` (
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8;
 
 CREATE TABLE IF NOT EXISTS `plugin_google_activity_recognition` (
-  `_id` int(11) NOT NULL AUTO_INCREMENT,
+  `_id` bigint unsigned NOT NULL AUTO_INCREMENT,
   `timestamp` double DEFAULT '0',
   `device_id` varchar(150) DEFAULT '',
   `activity_name` text,
@@ -490,7 +490,7 @@ CREATE TABLE IF NOT EXISTS `plugin_google_activity_recognition` (
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8;
 
 CREATE TABLE IF NOT EXISTS `plugin_google_login` (
-  `_id` int(11) NOT NULL AUTO_INCREMENT,
+  `_id` bigint unsigned NOT NULL AUTO_INCREMENT,
   `timestamp` double DEFAULT '0',
   `device_id` varchar(150) DEFAULT '',
   `name` text,
@@ -502,7 +502,7 @@ CREATE TABLE IF NOT EXISTS `plugin_google_login` (
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8;
 
 CREATE TABLE IF NOT EXISTS `plugin_openweather` (
-  `_id` int(11) NOT NULL AUTO_INCREMENT,
+  `_id` bigint unsigned NOT NULL AUTO_INCREMENT,
   `timestamp` double DEFAULT '0',
   `device_id` varchar(150) DEFAULT '',
   `city` text,
@@ -526,7 +526,7 @@ CREATE TABLE IF NOT EXISTS `plugin_openweather` (
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8;
 
 CREATE TABLE IF NOT EXISTS `plugin_studentlife_audio_android` (
-  `_id` int(11) NOT NULL AUTO_INCREMENT,
+  `_id` bigint unsigned NOT NULL AUTO_INCREMENT,
   `timestamp` double DEFAULT '0',
   `device_id` varchar(150) DEFAULT '',
   `datatype` int(11) DEFAULT '0',
@@ -579,7 +579,7 @@ CREATE TABLE IF NOT EXISTS `rotation_edited` (
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8;
 
 CREATE TABLE IF NOT EXISTS `screen` (
-  `_id` int(11) NOT NULL AUTO_INCREMENT,
+  `_id` bigint unsigned NOT NULL AUTO_INCREMENT,
   `timestamp` double DEFAULT '0',
   `device_id` varchar(150) DEFAULT '',
   `screen_status` int(11) DEFAULT '0',
@@ -811,7 +811,7 @@ CREATE TABLE IF NOT EXISTS `temperature` (
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8;
 
 CREATE TABLE IF NOT EXISTS `timezone` (
-  `_id` int(11) NOT NULL AUTO_INCREMENT,
+  `_id` bigint unsigned NOT NULL AUTO_INCREMENT,
   `timestamp` double DEFAULT '0',
   `device_id` varchar(150) DEFAULT '',
   `timezone` text,

--- a/App01/db-init.sql
+++ b/App01/db-init.sql
@@ -1,5 +1,5 @@
 CREATE TABLE IF NOT EXISTS `accelerometer` (
-  `_id` int(11) NOT NULL AUTO_INCREMENT,
+  `_id` bigint unsigned NOT NULL AUTO_INCREMENT,
   `timestamp` double DEFAULT '0',
   `device_id` varchar(150) DEFAULT '',
   `double_values_0` double DEFAULT '0',
@@ -164,7 +164,7 @@ CREATE TABLE IF NOT EXISTS `battery_discharges` (
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8;
 
 CREATE TABLE IF NOT EXISTS `bluetooth` (
-  `_id` int(11) NOT NULL AUTO_INCREMENT,
+  `_id` bigint unsigned NOT NULL AUTO_INCREMENT,
   `timestamp` double DEFAULT '0',
   `device_id` varchar(150) DEFAULT '',
   `bt_address` varchar(150) DEFAULT '',
@@ -269,7 +269,7 @@ CREATE TABLE IF NOT EXISTS `fused_geofences_data` (
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8;
 
 CREATE TABLE IF NOT EXISTS `gravity` (
-  `_id` int(11) NOT NULL AUTO_INCREMENT,
+  `_id` bigint unsigned NOT NULL AUTO_INCREMENT,
   `timestamp` double DEFAULT '0',
   `device_id` varchar(150) DEFAULT '',
   `double_values_0` double DEFAULT '0',
@@ -307,7 +307,7 @@ CREATE TABLE IF NOT EXISTS `gsm_neighbor` (
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8;
 
 CREATE TABLE IF NOT EXISTS `gyroscope` (
-  `_id` int(11) NOT NULL AUTO_INCREMENT,
+  `_id` bigint unsigned NOT NULL AUTO_INCREMENT,
   `timestamp` double DEFAULT '0',
   `device_id` varchar(150) DEFAULT '',
   `double_values_0` double DEFAULT '0',
@@ -345,7 +345,7 @@ CREATE TABLE IF NOT EXISTS `keyboard` (
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
 
 CREATE TABLE IF NOT EXISTS `light` (
-  `_id` int(11) NOT NULL AUTO_INCREMENT,
+  `_id` bigint unsigned NOT NULL AUTO_INCREMENT,
   `timestamp` double DEFAULT '0',
   `device_id` varchar(150) DEFAULT '',
   `double_light_lux` double DEFAULT '0',
@@ -356,7 +356,7 @@ CREATE TABLE IF NOT EXISTS `light` (
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8;
 
 CREATE TABLE IF NOT EXISTS `linear_accelerometer` (
-  `_id` int(11) NOT NULL AUTO_INCREMENT,
+  `_id` bigint unsigned NOT NULL AUTO_INCREMENT,
   `timestamp` double DEFAULT '0',
   `device_id` varchar(150) DEFAULT '',
   `double_values_0` double DEFAULT '0',
@@ -369,7 +369,7 @@ CREATE TABLE IF NOT EXISTS `linear_accelerometer` (
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8;
 
 CREATE TABLE IF NOT EXISTS `locations` (
-  `_id` int(11) NOT NULL AUTO_INCREMENT,
+  `_id` bigint unsigned NOT NULL AUTO_INCREMENT,
   `timestamp` double DEFAULT '0',
   `device_id` varchar(150) DEFAULT '',
   `double_latitude` double DEFAULT '0',
@@ -385,7 +385,7 @@ CREATE TABLE IF NOT EXISTS `locations` (
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8;
 
 CREATE TABLE IF NOT EXISTS `magnetometer` (
-  `_id` int(11) NOT NULL AUTO_INCREMENT,
+  `_id` bigint unsigned NOT NULL AUTO_INCREMENT,
   `timestamp` double DEFAULT '0',
   `device_id` varchar(150) DEFAULT '',
   `double_values_0` double DEFAULT '0',
@@ -428,7 +428,7 @@ CREATE TABLE IF NOT EXISTS `network` (
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8;
 
 CREATE TABLE IF NOT EXISTS `network_traffic` (
-  `_id` int(11) NOT NULL AUTO_INCREMENT,
+  `_id` bigint unsigned NOT NULL AUTO_INCREMENT,
   `timestamp` double DEFAULT '0',
   `device_id` varchar(150) DEFAULT '',
   `network_type` int(11) DEFAULT '0',
@@ -441,7 +441,7 @@ CREATE TABLE IF NOT EXISTS `network_traffic` (
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8;
 
 CREATE TABLE IF NOT EXISTS `plugin_ambient_noise` (
-  `_id` int(11) NOT NULL AUTO_INCREMENT,
+  `_id` bigint unsigned NOT NULL AUTO_INCREMENT,
   `timestamp` double DEFAULT '0',
   `device_id` varchar(150) DEFAULT '',
   `double_frequency` double DEFAULT '0',
@@ -540,7 +540,7 @@ CREATE TABLE IF NOT EXISTS `plugin_studentlife_audio_android` (
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8;
 
 CREATE TABLE IF NOT EXISTS `proximity` (
-  `_id` int(11) NOT NULL AUTO_INCREMENT,
+  `_id` bigint unsigned NOT NULL AUTO_INCREMENT,
   `timestamp` double DEFAULT '0',
   `device_id` varchar(150) DEFAULT '',
   `double_proximity` double DEFAULT '0',
@@ -551,7 +551,7 @@ CREATE TABLE IF NOT EXISTS `proximity` (
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8;
 
 CREATE TABLE IF NOT EXISTS `rotation` (
-  `_id` int(11) NOT NULL AUTO_INCREMENT,
+  `_id` bigint unsigned NOT NULL AUTO_INCREMENT,
   `timestamp` double DEFAULT '0',
   `device_id` varchar(150) DEFAULT '',
   `double_values_0` double DEFAULT '0',
@@ -565,7 +565,7 @@ CREATE TABLE IF NOT EXISTS `rotation` (
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8;
 
 CREATE TABLE IF NOT EXISTS `rotation_edited` (
-  `_id` int(11) NOT NULL AUTO_INCREMENT,
+  `_id` bigint unsigned NOT NULL AUTO_INCREMENT,
   `timestamp` double DEFAULT '0',
   `device_id` varchar(150) DEFAULT '',
   `double_values_0` double DEFAULT '0',
@@ -588,7 +588,7 @@ CREATE TABLE IF NOT EXISTS `screen` (
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8;
 
 CREATE TABLE IF NOT EXISTS `sensor_accelerometer` (
-  `_id` int(11) NOT NULL AUTO_INCREMENT,
+  `_id` bigint unsigned NOT NULL AUTO_INCREMENT,
   `timestamp` double DEFAULT '0',
   `device_id` varchar(150) DEFAULT '',
   `double_sensor_maximum_range` double DEFAULT '0',
@@ -604,7 +604,7 @@ CREATE TABLE IF NOT EXISTS `sensor_accelerometer` (
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8;
 
 CREATE TABLE IF NOT EXISTS `sensor_barometer` (
-  `_id` int(11) NOT NULL AUTO_INCREMENT,
+  `_id` bigint unsigned NOT NULL AUTO_INCREMENT,
   `timestamp` double DEFAULT '0',
   `device_id` varchar(150) DEFAULT '',
   `double_sensor_maximum_range` double DEFAULT '0',
@@ -620,7 +620,7 @@ CREATE TABLE IF NOT EXISTS `sensor_barometer` (
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8;
 
 CREATE TABLE IF NOT EXISTS `sensor_bluetooth` (
-  `_id` int(11) NOT NULL AUTO_INCREMENT,
+  `_id` bigint unsigned NOT NULL AUTO_INCREMENT,
   `timestamp` double DEFAULT '0',
   `device_id` varchar(150) DEFAULT '',
   `bt_address` varchar(150) DEFAULT '',
@@ -630,7 +630,7 @@ CREATE TABLE IF NOT EXISTS `sensor_bluetooth` (
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8;
 
 CREATE TABLE IF NOT EXISTS `sensor_gravity` (
-  `_id` int(11) NOT NULL AUTO_INCREMENT,
+  `_id` bigint unsigned NOT NULL AUTO_INCREMENT,
   `timestamp` double DEFAULT '0',
   `device_id` varchar(150) DEFAULT '',
   `double_sensor_maximum_range` double DEFAULT '0',
@@ -646,7 +646,7 @@ CREATE TABLE IF NOT EXISTS `sensor_gravity` (
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8;
 
 CREATE TABLE IF NOT EXISTS `sensor_gyroscope` (
-  `_id` int(11) NOT NULL AUTO_INCREMENT,
+  `_id` bigint unsigned NOT NULL AUTO_INCREMENT,
   `timestamp` double DEFAULT '0',
   `device_id` varchar(150) DEFAULT '',
   `double_sensor_maximum_range` double DEFAULT '0',
@@ -662,7 +662,7 @@ CREATE TABLE IF NOT EXISTS `sensor_gyroscope` (
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8;
 
 CREATE TABLE IF NOT EXISTS `sensor_light` (
-  `_id` int(11) NOT NULL AUTO_INCREMENT,
+  `_id` bigint unsigned NOT NULL AUTO_INCREMENT,
   `timestamp` double DEFAULT '0',
   `device_id` varchar(150) DEFAULT '',
   `double_sensor_maximum_range` double DEFAULT '0',
@@ -678,7 +678,7 @@ CREATE TABLE IF NOT EXISTS `sensor_light` (
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8;
 
 CREATE TABLE IF NOT EXISTS `sensor_linear_accelerometer` (
-  `_id` int(11) NOT NULL AUTO_INCREMENT,
+  `_id` bigint unsigned NOT NULL AUTO_INCREMENT,
   `timestamp` double DEFAULT '0',
   `device_id` varchar(150) DEFAULT '',
   `double_sensor_maximum_range` double DEFAULT '0',
@@ -694,7 +694,7 @@ CREATE TABLE IF NOT EXISTS `sensor_linear_accelerometer` (
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8;
 
 CREATE TABLE IF NOT EXISTS `sensor_magnetometer` (
-  `_id` int(11) NOT NULL AUTO_INCREMENT,
+  `_id` bigint unsigned NOT NULL AUTO_INCREMENT,
   `timestamp` double DEFAULT '0',
   `device_id` varchar(150) DEFAULT '',
   `double_sensor_maximum_range` double DEFAULT '0',
@@ -710,7 +710,7 @@ CREATE TABLE IF NOT EXISTS `sensor_magnetometer` (
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8;
 
 CREATE TABLE IF NOT EXISTS `sensor_proximity` (
-  `_id` int(11) NOT NULL AUTO_INCREMENT,
+  `_id` bigint unsigned NOT NULL AUTO_INCREMENT,
   `timestamp` double DEFAULT '0',
   `device_id` varchar(150) DEFAULT '',
   `double_sensor_maximum_range` double DEFAULT '0',
@@ -726,7 +726,7 @@ CREATE TABLE IF NOT EXISTS `sensor_proximity` (
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8;
 
 CREATE TABLE IF NOT EXISTS `sensor_rotation` (
-  `_id` int(11) NOT NULL AUTO_INCREMENT,
+  `_id` bigint unsigned NOT NULL AUTO_INCREMENT,
   `timestamp` double DEFAULT '0',
   `device_id` varchar(150) DEFAULT '',
   `double_sensor_maximum_range` double DEFAULT '0',
@@ -742,7 +742,7 @@ CREATE TABLE IF NOT EXISTS `sensor_rotation` (
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8;
 
 CREATE TABLE IF NOT EXISTS `sensor_temperature` (
-  `_id` int(11) NOT NULL AUTO_INCREMENT,
+  `_id` bigint unsigned NOT NULL AUTO_INCREMENT,
   `timestamp` double DEFAULT '0',
   `device_id` varchar(150) DEFAULT '',
   `double_sensor_maximum_range` double DEFAULT '0',
@@ -758,7 +758,7 @@ CREATE TABLE IF NOT EXISTS `sensor_temperature` (
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8;
 
 CREATE TABLE IF NOT EXISTS `sensor_wifi` (
-  `_id` int(11) NOT NULL AUTO_INCREMENT,
+  `_id` bigint unsigned NOT NULL AUTO_INCREMENT,
   `timestamp` double DEFAULT '0',
   `device_id` varchar(150) DEFAULT '',
   `mac_address` text,
@@ -769,7 +769,7 @@ CREATE TABLE IF NOT EXISTS `sensor_wifi` (
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8;
 
 CREATE TABLE IF NOT EXISTS `significant` (
-  `_id` int(11) NOT NULL AUTO_INCREMENT,
+  `_id` bigint unsigned NOT NULL AUTO_INCREMENT,
   `timestamp` double DEFAULT '0',
   `device_id` varchar(150) DEFAULT '',
   `is_moving` int(11) DEFAULT '0',
@@ -778,7 +778,7 @@ CREATE TABLE IF NOT EXISTS `significant` (
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8;
 
 CREATE TABLE IF NOT EXISTS `telephony` (
-  `_id` int(11) NOT NULL AUTO_INCREMENT,
+  `_id` bigint unsigned NOT NULL AUTO_INCREMENT,
   `timestamp` double DEFAULT '0',
   `device_id` varchar(150) DEFAULT '',
   `data_enabled` int(11) DEFAULT '0',
@@ -800,7 +800,7 @@ CREATE TABLE IF NOT EXISTS `telephony` (
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8;
 
 CREATE TABLE IF NOT EXISTS `temperature` (
-  `_id` int(11) NOT NULL AUTO_INCREMENT,
+  `_id` bigint unsigned NOT NULL AUTO_INCREMENT,
   `timestamp` double DEFAULT '0',
   `device_id` varchar(150) DEFAULT '',
   `temperature_celsius` double DEFAULT '0',
@@ -820,7 +820,7 @@ CREATE TABLE IF NOT EXISTS `timezone` (
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8;
 
 CREATE TABLE IF NOT EXISTS `touch` (
-  `_id` int(11) NOT NULL AUTO_INCREMENT,
+  `_id` bigint unsigned NOT NULL AUTO_INCREMENT,
   `timestamp` double DEFAULT '0',
   `device_id` varchar(150) DEFAULT '',
   `touch_app` text,
@@ -834,7 +834,7 @@ CREATE TABLE IF NOT EXISTS `touch` (
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8;
 
 CREATE TABLE IF NOT EXISTS `wifi` (
-  `_id` int(11) NOT NULL AUTO_INCREMENT,
+  `_id` bigint unsigned NOT NULL AUTO_INCREMENT,
   `timestamp` double DEFAULT '0',
   `device_id` varchar(150) DEFAULT '',
   `bssid` varchar(255) DEFAULT '',
@@ -848,7 +848,7 @@ CREATE TABLE IF NOT EXISTS `wifi` (
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8;
 
 CREATE TABLE IF NOT EXISTS `screentext` (
-    `_id` int(11) NOT NULL AUTO_INCREMENT,
+    `_id` bigint unsigned NOT NULL AUTO_INCREMENT,
     `timestamp` double DEFAULT '0',
     `device_id` varchar(150) DEFAULT '',
     `class_name` varchar(150) DEFAULT '',


### PR DESCRIPTION
Fix for [#Issue 28](https://github.com/awareframework/aware-light-client/issues/28): BIGINT for _id column.

This change anticipates growth in data volume and prevents potential integer overflow issues in large-scale tests.